### PR TITLE
W-19149055: Edit messages for the 10 new "orchestrator" commands

### DIFF
--- a/messages/appframework.create.app.md
+++ b/messages/appframework.create.app.md
@@ -16,39 +16,35 @@ You must have Data Cloud and Tableau Next enabled in your org and the AppFramewo
 
 - Create an app from a template by ID:
 
-  <%= config.bin %> <%= command.id %> --target-org myOrg --name "my_app" --template-id 01t000000000123
+  <%= config.bin %> <%= command.id %> --target-org myOrg --name my_app --template-id 01t000000000123
 
 - Create an app from a template by name:
 
-  <%= config.bin %> <%= command.id %> --target-org myOrg --name "sales_app" --template-name "Sales_Template"
+  <%= config.bin %> <%= command.id %> --target-org myOrg --name sales_app --template-name Sales_Template
 
 - Create an app with a custom label and description:
 
-  <%= config.bin %> <%= command.id %> --target-org myOrg --name "analytics_app" --template-name "Analytics_Template" --label "My Analytics App" --description "Custom analytics app"
+  <%= config.bin %> <%= command.id %> --target-org myOrg --name analytics_app --template-name Analytics_Template --label "My Analytics App" --description "Custom analytics app"
 
 - Create an app with specific runtime configuration:
 
-  <%= config.bin %> <%= command.id %> --target-org myOrg --name "dashboard_app" --template-id 01t000000000456 --runtime-method async --log-level debug
+  <%= config.bin %> <%= command.id %> --target-org myOrg --name dashboard_app --template-id 01t000000000456 --runtime-method async --log-level debug
 
 - Create an app using a specific API version:
 
-  <%= config.bin %> <%= command.id %> --target-org mySandbox --name "test_app" --template-name "Test Template" --api-version 60.0
+  <%= config.bin %> <%= command.id %> --target-org mySandbox --name test_app --template-name "Test Template" --api-version 60.0
 
 # flags.target-org.summary
 
-Login username or alias for the target org.
-
-# flags.target-org.description
-
-The target org to connect to for creating the app. This org must have Data Cloud and Tableau Next enabled and you must have the AppFrameworkManageApp user permission to create apps. The template must also exist in this org.
+Login username or alias for the target org. Not required if the `target-org` configuration variable is already set.
 
 # flags.api-version.summary
 
-Override the API version used for API requests.
+Override the API version used for orchestrator API requests.
 
 # flags.api-version.description
 
-Override the API version used for orchestrator API requests. Use this flag to specify a particular API version when the default version doesn't work with your org's configuration.
+Use this flag to specify a particular API version when the default version doesn't work with your org's configuration.
 
 # flags.name.summary
 
@@ -78,17 +74,9 @@ A description of what the app does and its intended use case. This helps users u
 
 ID of the template to use for creating the app.
 
-# flags.template-id.description
-
-The unique identifier of the template to use for generating the new app.
-
 # flags.template-name.summary
 
 Name of the template to use for creating the app.
-
-# flags.template-name.description
-
-The name of the template to use for generating the new app.
 
 # flags.runtime-method.summary
 
@@ -96,7 +84,7 @@ Runtime method for the app.
 
 # flags.runtime-method.description
 
-Specifies the runtime method for the app execution. This affects how the app processes data and handles user interactions. Valid values are 'sync' and 'async'.
+Specifies the runtime method for the app execution. This affects how the app processes data and handles user interactions.
 
 # flags.log-level.summary
 
@@ -104,7 +92,7 @@ Log level for the app.
 
 # flags.log-level.description
 
-Sets the logging level for the app. This controls how much diagnostic information is captured during app execution. Valid values are 'debug', 'info', 'warn', and 'error'.
+Sets the logging level for the app. This controls how much diagnostic information is captured during app execution.
 
 # noTemplateSpecified
 
@@ -120,7 +108,7 @@ Creating app from template...
 
 # createSuccess
 
-Successfully created app with ID: %s
+Successfully created app with ID: %s.
 
 # error.MissingRequiredFlag
 
@@ -128,9 +116,9 @@ Either --template-id or --template-name must be provided.
 
 # error.MissingRequiredFlag.Actions
 
-- Use --template-id to specify a template by its unique ID
-- Use --template-name to specify a template by its name
-- Get template IDs and names using "sf orchestrator template list"
+- Use --template-id to specify a template by its unique ID.
+- Use --template-name to specify a template by its name.
+- Get template IDs and names using "sf orchestrator template list".
 
 # error.TemplateNotFound
 
@@ -138,22 +126,22 @@ Template not found.
 
 # error.TemplateNotFound.Actions
 
-- Verify the template ID or name is correct
-- Use "sf orchestrator template list" to see available templates
-- Check your permissions to view templates
-- Make sure you're connected to the correct org with --target-org
+- Verify the template ID or name is correct.
+- Use "sf orchestrator template list" to see available templates.
+- Check your permissions to view templates.
+- Make sure you're connected to the correct org with --target-org.
 
 # error.AppCreationError
 
-Failed to create app: %s
+Failed to create app: %s.
 
 # error.AppCreationError.Actions
 
-- Verify that you have permission to create apps in the target org
-- Ensure the app name is unique within your org
-- Check that Data Cloud and Tableau Next are enabled in your org
-- Verify your authentication and org connection are valid
-- Try using a different API version with --api-version
+- Verify that you have permission to create apps in the target org.
+- Ensure the app name is unique within your org.
+- Check that Data Cloud and Tableau Next are enabled in your org.
+- Verify your authentication and org connection are valid.
+- Try using a different API version with --api-version.
 
 # error.InvalidAppName
 
@@ -161,10 +149,10 @@ App name "%s" is invalid or already exists.
 
 # error.InvalidAppName.Actions
 
-- Choose a unique name that doesn't exist in your org
-- Ensure the name follows your org's naming conventions
-- Use "sf orchestrator app list" to see existing app names
-- Avoid special characters and spaces in app names
+- Choose a unique name that doesn't exist in your org.
+- Ensure the name follows your org's naming conventions.
+- Use "sf orchestrator app list" to see existing app names.
+- Avoid special characters and spaces in app names.
 
 # error.InsufficientPermissions
 
@@ -172,7 +160,7 @@ You don't have permission to create apps in this org.
 
 # error.InsufficientPermissions.Actions
 
-- Contact your Salesforce admin to request app creation permissions
-- Verify you're connected to the correct org with --target-org
-- Check that Data Cloud and Tableau Next are enabled in your org
-- Check that your user profile has the AppFrameworkManageApp user permission
+- Contact your Salesforce admin to request app creation permissions.
+- Verify you're connected to the correct org with --target-org.
+- Check that Data Cloud and Tableau Next are enabled in your org.
+- Check that your user profile has the AppFrameworkManageApp user permission.

--- a/messages/appframework.create.template.md
+++ b/messages/appframework.create.template.md
@@ -14,39 +14,35 @@ You must have Data Cloud and Tableau Next enabled in your org and the AppFramewo
 
 - Create a basic app template:
 
-  <%= config.bin %> <%= command.id %> --target-org myOrg --name "my_template"
+  <%= config.bin %> <%= command.id %> --target-org myOrg --name my_template
 
 - Create a template with a label for better identification:
 
-  <%= config.bin %> <%= command.id %> --target-org myOrg --name "sales_template" --label "Sales Analytics Template"
+  <%= config.bin %> <%= command.id %> --target-org myOrg --name sales_template --label "Sales Analytics Template"
 
 - Create a dashboard template with a specific subtype:
 
-  <%= config.bin %> <%= command.id %> --target-org myOrg --name "dashboard_template" --type dashboard --subtype "analytics"
+  <%= config.bin %> <%= command.id %> --target-org myOrg --name dashboard_template --type dashboard --subtype analytics
 
 - Create a comprehensive template with all metadata:
 
-  <%= config.bin %> <%= command.id %> --target-org myOrg --name "analytics_template" --type app --subtype "tableau" --label "Sales Template" --description "Template for sales analytics apps"
+  <%= config.bin %> <%= command.id %> --target-org myOrg --name analytics_template --type app --subtype tableau --label "Sales Template" --description "Template for sales analytics apps"
 
 - Create a template using a specific API version:
 
-  <%= config.bin %> <%= command.id %> --target-org myOrg --name "legacy_template" --api-version 60.0
+  <%= config.bin %> <%= command.id %> --target-org myOrg --name legacy_template --api-version 60.0
 
 # flags.target-org.summary
 
-Login username or alias for the target org.
-
-# flags.target-org.description
-
-The target org to connect to for creating the template. This org must have Data Cloud and Tableau Next enabled and you must have the AppFrameworkManageApp user permission to create templates.
+Login username or alias for the target org. Not required if the `target-org` configuration variable is already set.
 
 # flags.api-version.summary
 
-Override the API version used for API requests.
+Override the API version used for orchestrator API requests.
 
 # flags.api-version.description
 
-Override the API version used for orchestrator API requests. Use this flag to specify a particular API version when the default version doesn't work with your org's configuration.
+Use this flag to specify a particular API version when the default version doesn't work with your org's configuration.
 
 # flags.name.summary
 
@@ -62,7 +58,7 @@ Type of template to create.
 
 # flags.type.description
 
-Specifies the type of template to create. Valid values are 'app', 'component', 'dashboard', or 'lens'. Defaults to 'app' if not specified. Choose the type that matches your intended use case for the template.
+Specifies the type of template to create. Choose the type that matches your intended use case for the template.
 
 # flags.subtype.summary
 
@@ -70,7 +66,7 @@ Subtype for the template.
 
 # flags.subtype.description
 
-An optional subtype categorization for the template (e.g., 'tableau' for app templates). Subtypes help organize templates and provide additional context about their intended use or underlying technology.
+An optional subtype categorization for the template, such as 'tableau' for app templates. Subtypes help organize templates and provide additional context about their intended use or underlying technology.
 
 # flags.label.summary
 
@@ -78,7 +74,7 @@ Label for the new template.
 
 # flags.label.description
 
-A human-readable label for the template. This is displayed in Tableau Next and helps users identify the template's purpose. Use clear, descriptive labels that explain what the template does.
+A human-readable label for the template. This label is displayed in Tableau Next and helps users identify the template's purpose. Use clear, descriptive labels that explain what the template does.
 
 # flags.description.summary
 
@@ -86,7 +82,7 @@ Description of the new template.
 
 # flags.description.description
 
-A description of what the template does and its intended use case. This is displayed in Tableau Next and helps users understand when to use this template. Include information about the template's purpose, features, and any prerequisites.
+A description of what the template does and its intended use case. This description is displayed in Tableau Next and helps users understand when to use this template. Include information about the template's purpose, features, and any prerequisites.
 
 # fetchingApp
 
@@ -98,19 +94,19 @@ Creating template from app...
 
 # createSuccess
 
-Successfully created template with ID: %s
+Successfully created template with ID: %s.
 
 # error.TemplateCreationError
 
-Error creating template: %s
+Error creating template: %s.
 
 # error.TemplateCreationError.Actions
 
-- Verify that you have permission to create templates in the target org
-- Ensure the template name is unique within your org
-- Check that Data Cloud and Tableau Next are enabled in your org
-- Verify your authentication and org connection are valid
-- Try using a different API version with --api-version
+- Verify that you have permission to create templates in the target org.
+- Ensure the template name is unique within your org.
+- Check that Data Cloud and Tableau Next are enabled in your org.
+- Verify your authentication and org connection are valid.
+- Try using a different API version with --api-version.
 
 # error.InvalidTemplateName
 
@@ -118,10 +114,10 @@ Template name "%s" is invalid or already exists.
 
 # error.InvalidTemplateName.Actions
 
-- Choose a unique name that doesn't exist in your org
-- Ensure the name follows your org's naming conventions
-- Use "sf orchestrator template list" to see existing template names
-- Avoid special characters and spaces in template names
+- Choose a unique name that doesn't exist in your org.
+- Ensure the name follows your org's naming conventions.
+- Use "sf orchestrator template list" to see existing template names.
+- Avoid special characters and spaces in template names.
 
 # error.InsufficientPermissions
 
@@ -129,7 +125,7 @@ You don't have permission to create templates in this org.
 
 # error.InsufficientPermissions.Actions
 
-- Contact your Salesforce admin to request template creation permissions
-- Verify you're connected to the correct org with --target-org
-- Check that Data Cloud and Tableau Next are enabled in your org
-- Check that your user profile has the AppFrameworkManageApp permission
+- Contact your Salesforce admin to request template creation permissions.
+- Verify you're connected to the correct org with --target-org.
+- Check that Data Cloud and Tableau Next are enabled in your org.
+- Check that your user profile has the AppFrameworkManageApp permission.

--- a/messages/appframework.delete.app.md
+++ b/messages/appframework.delete.app.md
@@ -14,39 +14,27 @@ You must have Data Cloud and Tableau Next enabled in your org and the AppFramewo
 
 # flags.target-org.summary
 
-Login username or alias for the target org.
-
-# flags.target-org.description
-
-The target org to connect to for deleting the app. This org must have Data Cloud and Tableau Next enabled and you must have the AppFrameworkManageApp user permission to delete apps. The app must exist in this org.
+Login username or alias for the target org. Not required if the `target-org` configuration variable is already set.
 
 # flags.api-version.summary
 
-Override the API version used for API requests.
+Override the API version used for orchestrator API requests.
 
 # flags.api-version.description
 
-Override the API version used for orchestrator API requests. Use this flag to specify a particular API version when the default version doesn't work with your org's configuration.
+Use this flag to specify a particular API version when the default version doesn't work with your org's configuration.
 
 # flags.app-id.summary
 
 ID of the app to delete.
 
-# flags.app-id.description
-
-The unique identifier of the app to delete.
-
 # flags.app-name.summary
 
 Name of the app to delete.
 
-# flags.app-name.description
-
-The name of the app to delete.
-
 # flags.no-prompt.summary
 
-Do not prompt for confirmation.
+Don't prompt for confirmation.
 
 # flags.no-prompt.description
 
@@ -70,7 +58,7 @@ No app found with the specified ID or name.
 
 # confirmDelete
 
-Are you sure you want to delete the app '%s'? This action cannot be undone.
+Are you sure you want to delete the app '%s'? This action can't be undone.
 
 # deleteCancelled
 
@@ -78,7 +66,7 @@ App deletion cancelled.
 
 # deleteSuccess
 
-Successfully deleted app with ID: %s
+Successfully deleted app with ID: %s.
 
 # error.MissingRequiredFlag
 
@@ -86,9 +74,9 @@ Either --app-id or --app-name must be provided.
 
 # error.MissingRequiredFlag.Actions
 
-- Use --app-id to specify an app by its unique ID
-- Use --app-name to specify an app by its name
-- Get app IDs and names using "sf orchestrator app list"
+- Use --app-id to specify an app by its unique ID.
+- Use --app-name to specify an app by its name.
+- Get app IDs and names using "sf orchestrator app list".
 
 # error.AppNotFound
 
@@ -96,22 +84,22 @@ App "%s" not found.
 
 # error.AppNotFound.Actions
 
-- Verify the app ID or name is correct
-- Use "sf orchestrator app list" to see available apps
-- Check your permissions to view apps
-- Make sure you're connected to the correct org with --target-org
+- Verify the app ID or name is correct.
+- Use "sf orchestrator app list" to see available apps.
+- Check your permissions to view apps.
+- Make sure you're connected to the correct org with --target-org.
 
 # error.DeleteError
 
-Failed to delete app: %s
+Failed to delete app: %s.
 
 # error.DeleteError.Actions
 
-- Verify that you have permission to delete apps in the target org
-- Check that the app exists and is accessible
-- Ensure Data Cloud and Tableau Next are enabled in your org
-- Try using a different API version with --api-version
-- Verify your authentication and org connection are valid
+- Verify that you have permission to delete apps in the target org.
+- Check that the app exists and is accessible.
+- Ensure Data Cloud and Tableau Next are enabled in your org.
+- Try using a different API version with --api-version.
+- Verify your authentication and org connection are valid.
 
 # error.InsufficientPermissions
 
@@ -119,21 +107,21 @@ You don't have permission to delete apps in this org.
 
 # error.InsufficientPermissions.Actions
 
-- Contact your Salesforce admin to request app deletion permissions
-- Verify you're connected to the correct org with --target-org
-- Ensure Data Cloud and Tableau Next are enabled in your org
-- Check that your user profile has the AppFrameworkManageApp permission
+- Contact your Salesforce admin to request app deletion permissions.
+- Verify you're connected to the correct org with --target-org.
+- Ensure Data Cloud and Tableau Next are enabled in your org.
+- Check that your user profile has the AppFrameworkManageApp permission.
 
 # error.AppInUse
 
-Can't delete app: It is currently in use by active processes.
+Can't delete app: It's currently in use by active processes.
 
 # error.AppInUse.Actions
 
-- Wait for any active processes using this app to complete
-- Check which processes are using this app
-- Consider stopping dependent processes before deletion
-- Try again after active processes have finished
+- Wait for any active processes using this app to complete.
+- Check which processes are using this app.
+- Consider stopping dependent processes before deletion.
+- Try again after active processes have finished.
 
 # error.MultipleAppsFound
 
@@ -141,9 +129,9 @@ Multiple apps found with name "%s".
 
 # error.MultipleAppsFound.Actions
 
-- Use --app-id instead of --app-name for unique identification
-- Get the specific app ID using "sf orchestrator app list"
-- App names should be unique, but this org may have duplicates
+- Use --app-id instead of --app-name for unique identification.
+- Get the specific app ID using "sf orchestrator app list".
+- App names should be unique, but this org may have duplicates.
 
 # error.InvalidAppId
 
@@ -151,9 +139,9 @@ App ID "%s" is not valid.
 
 # error.InvalidAppId.Actions
 
-- Verify the app ID format is correct
-- Get valid app IDs using "sf orchestrator app list"
-- App IDs should be 15 or 18 character Salesforce IDs
+- Verify the app ID format is correct.
+- Get valid app IDs using "sf orchestrator app list".
+- App IDs should be 15 or 18 character Salesforce IDs.
 
 # examples
 

--- a/messages/appframework.delete.template.md
+++ b/messages/appframework.delete.template.md
@@ -40,19 +40,15 @@ You must have Data Cloud and Tableau Next enabled in your org and the AppFramewo
 
 # flags.target-org.summary
 
-Login username or alias for the target org.
-
-# flags.target-org.description
-
-The target org to connect to for deleting the template. This org must have Data Cloud and Tableau Next enabled and you must have the AppFrameworkManageApp user permission to delete templates. The template must exist in this org.
+Login username or alias for the target org. Not required if the `target-org` configuration variable is already set.
 
 # flags.api-version.summary
 
-Override the API version used for API requests.
+Override the API version used for orchestrator API requests.
 
 # flags.api-version.description
 
-Override the API version used for orchestrator API requests. Use this flag to specify a particular API version when the default version doesn't work with your org's configuration.
+Use this flag to specify a particular API version when the default version doesn't work with your org's configuration.
 
 # flags.template-id.summary
 
@@ -68,7 +64,7 @@ Name of the template to delete.
 
 # flags.template-name.description
 
-The name of the template to delete. Template names should be unique within an org. Use this flag when you know the template's name but not its ID. If the name contains spaces, enclose it in quotes. Either --template-id or --template-name is required.
+Template names should be unique within an org. Use this flag when you know the template's name but not its ID. If the name contains spaces, enclose it in quotes. Either --template-id or --template-name is required.
 
 # flags.force-delete.summary
 
@@ -76,7 +72,7 @@ Force delete the template and all apps created from it.
 
 # flags.force-delete.description
 
-When set, all apps created from this template are also deleted. This is a destructive operation that can't be undone. Use with caution as it permanently removes both the template and all associated apps from your org.
+When specified, all apps created from this template are also deleted. This is a destructive operation that can't be undone. Use with caution as it permanently removes both the template and all associated apps from your org.
 
 # flags.decouple.summary
 
@@ -84,7 +80,7 @@ Decouple apps from this template before deleting it.
 
 # flags.decouple.description
 
-When set, apps created from this template have their association with the template removed before the template is deleted. This ensures apps continue to function independently after the template is gone. Use this option when you want to preserve apps while removing the template.
+When specified, apps created from this template have their association with the template removed before the template is deleted. This ensures apps continue to function independently after the template is gone. Use this option when you want to preserve apps while removing the template.
 
 # flags.no-prompt.summary
 
@@ -116,15 +112,15 @@ Are you sure you want to delete this template? Apps created from it will remain 
 
 # confirmForceDeleteYesNo
 
-WARNING: This will delete the template AND all apps created from it. This operation cannot be undone. Continue? (y/n)
+WARNING: This operation will delete the template AND all apps created from it. This operation can't be undone. Continue? (y/n)
 
 # confirmDecoupleYesNo
 
-This will decouple all apps from the template and then delete the template. Apps will remain independent after the template is gone. Continue? (y/n)
+This operation will decouple all apps from the template and then delete the template. Apps will remain independent after the template is gone. Continue? (y/n)
 
 # deleteTemplateSuccess
 
-Successfully deleted template with ID: %s
+Successfully deleted template with ID: %s.
 
 # error.MissingRequiredFlag
 
@@ -132,20 +128,20 @@ You must provide either --template-id or --template-name.
 
 # error.MissingRequiredFlag.Actions
 
-- Use --template-id to specify a template by its unique ID
-- Use --template-name to specify a template by its name
-- Get template IDs and names using "sf orchestrator template list"
+- Use --template-id to specify a template by its unique ID.
+- Use --template-name to specify a template by its name.
+- Get template IDs and names using "sf orchestrator template list".
 
 # error.TemplateNotFound
 
-Could not find template: %s
+Couldn't find template: %s.
 
 # error.TemplateNotFound.Actions
 
-- Verify the template ID or name is correct
-- Use "sf orchestrator template list" to see available templates
-- Check your permissions to view templates
-- Make sure you're connected to the correct org with --target-org
+- Verify the template ID or name is correct.
+- Use "sf orchestrator template list" to see available templates.
+- Check your permissions to view templates.
+- Make sure you're connected to the correct org with --target-org.
 
 # error.CertificateError
 
@@ -153,10 +149,10 @@ Error connecting to Salesforce: Certificate validation failed.
 
 # error.CertificateError.Actions
 
-- Check your network connection
-- Verify you have valid certificates
-- Try specifying the API version with --api-version
-- If using a sandbox or scratch org, ensure your connection is properly authenticated
+- Check your network connection.
+- Verify you have valid certificates.
+- Try specifying the API version with --api-version.
+- If using a sandbox or scratch org, ensure your connection is properly authenticated.
 
 # error.AuthenticationError
 
@@ -164,21 +160,21 @@ Error connecting to Salesforce: Authentication failed.
 
 # error.AuthenticationError.Actions
 
-- Verify your credentials are valid
-- Run "sf org login web" to reauthenticate
-- Check if your session has expired
-- Ensure you have Data Cloud and Tableau Next enabled and the AppFrameworkManageApp user permission
+- Verify your credentials are valid.
+- Run "sf org login web" to reauthenticate.
+- Check if your session has expired.
+- Ensure you have Data Cloud and Tableau Next enabled and the AppFrameworkManageApp user permission.
 
 # error.GenericError
 
-Error deleting template: %s
+Error deleting template: %s.
 
 # error.GenericError.Actions
 
-- Review the error message for details
-- Check if you have permission to delete templates
-- Verify the template isn't locked or protected
-- Ensure Data Cloud and Tableau Next are enabled in your org
+- Review the error message for details.
+- Check if you have permission to delete templates.
+- Verify the template isn't locked or protected.
+- Ensure Data Cloud and Tableau Next are enabled in your org.
 
 # error.InsufficientPermissions
 
@@ -186,29 +182,29 @@ You don't have permission to delete templates in this org.
 
 # error.InsufficientPermissions.Actions
 
-- Contact your Salesforce admin to request template deletion permissions
-- Verify you're connected to the correct org with --target-org
-- Ensure Data Cloud and Tableau Next are enabled in your org
-- Check that your user profile has the AppFrameworkManageApp user permission
+- Contact your Salesforce admin to request template deletion permissions.
+- Verify you're connected to the correct org with --target-org.
+- Ensure Data Cloud and Tableau Next are enabled in your org.
+- Check that your user profile has the AppFrameworkManageApp user permission.
 
 # error.TemplateInUse
 
-Can't delete template: It is currently in use by active processes.
+Can't delete template: It's currently in use by active processes.
 
 # error.TemplateInUse.Actions
 
-- Wait for any active processes using this template to complete
-- Use --force-delete to delete the template and all associated apps
-- Use --decouple to preserve apps while deleting the template
-- Check which apps are using this template with "sf orchestrator app list"
+- Wait for any active processes using this template to complete.
+- Use --force-delete to delete the template and all associated apps.
+- Use --decouple to preserve apps while deleting the template.
+- Check which apps are using this template with "sf orchestrator app list".
 
 # deleteAppSuccess
 
-Successfully deleted app '%s' (ID: %s)
+Successfully deleted app '%s' (ID: %s).
 
 # decoupleAppSuccess
 
-Successfully decoupled app '%s' (ID: %s) from template
+Successfully decoupled app '%s' (ID: %s) from template.
 
 # deletionCancelled
 

--- a/messages/appframework.display.app.md
+++ b/messages/appframework.display.app.md
@@ -1,6 +1,6 @@
 # summary
 
-Display details of an app.
+Display details about an app.
 
 # description
 
@@ -14,35 +14,23 @@ You must have Data Cloud and Tableau Next enabled in your org and the AppFramewo
 
 # flags.target-org.summary
 
-Login username or alias for the target org.
-
-# flags.target-org.description
-
-The target org to connect to for displaying the app. This org must have Data Cloud and Tableau Next enabled and you must have the AppFrameworkViewApp user permission to view apps. The app must also exist in this org.
+Login username or alias for the target org. Not required if the `target-org` configuration variable is already set.
 
 # flags.api-version.summary
 
-Override the API version used for API requests.
+Override the API version used for orchestrator API requests.
 
 # flags.api-version.description
 
-Override the API version used for orchestrator API requests. Use this flag to specify a particular API version when the default version doesn't work with your org's configuration.
+Use this flag to specify a particular API version when the default version doesn't work with your org's configuration.
 
 # flags.app-id.summary
 
 ID of the app to display.
 
-# flags.app-id.description
-
-The unique identifier of the app to display.
-
 # flags.app-name.summary
 
 Name of the app to display.
-
-# flags.app-name.description
-
-The name of the app to display.
 
 # noAppSpecified
 
@@ -62,9 +50,9 @@ Either --app-id or --app-name must be provided.
 
 # error.MissingRequiredFlag.Actions
 
-- Use --app-id to specify an app by its unique ID
-- Use --app-name to specify an app by its name
-- Get app IDs and names using "sf orchestrator app list"
+- Use --app-id to specify an app by its unique ID.
+- Use --app-name to specify an app by its name.
+- Get app IDs and names using "sf orchestrator app list".
 
 # error.AppNotFound
 
@@ -72,22 +60,22 @@ App "%s" not found.
 
 # error.AppNotFound.Actions
 
-- Verify that you have the correct app ID or name
-- Ensure the app exists in this org using "sf orchestrator app list"
-- Check your permissions to view apps
-- Make sure you're connected to the correct org with --target-org
+- Verify that you have the correct app ID or name.
+- Ensure the app exists in this org using "sf orchestrator app list".
+- Check your permissions to view apps.
+- Make sure you're connected to the correct org with --target-org.
 
 # error.RetrievalError
 
-Failed to retrieve app details: %s
+Failed to retrieve app details: %s.
 
 # error.RetrievalError.Actions
 
-- Verify that you have permission to view apps in the target org
-- Check that the app exists and is accessible
-- Ensure that Data Cloud and Tableau Next are enabled in your org
-- Try using a different API version with --api-version
-- Verify your authentication and org connection are valid
+- Verify that you have permission to view apps in the target org.
+- Check that the app exists and is accessible.
+- Ensure that Data Cloud and Tableau Next are enabled in your org.
+- Try using a different API version with --api-version.
+- Verify your authentication and org connection are valid.
 
 # error.InsufficientPermissions
 
@@ -95,10 +83,10 @@ You don't have permission to view apps in this org.
 
 # error.InsufficientPermissions.Actions
 
-- Contact your Salesforce admin to request app view permissions
-- Verify you're connected to the correct org with --target-org
-- Ensure that Data Cloud and Tableau Next are enabled in your org
-- Check that your user profile has the AppFrameworkViewApp user permission
+- Contact your Salesforce admin to request app view permissions.
+- Verify you're connected to the correct org with --target-org.
+- Ensure that Data Cloud and Tableau Next are enabled in your org.
+- Check that your user profile has the AppFrameworkViewApp user permission.
 
 # error.MultipleAppsFound
 
@@ -106,9 +94,9 @@ Multiple apps found with name "%s".
 
 # error.MultipleAppsFound.Actions
 
-- Use --app-id instead of --app-name for unique identification
-- Get the specific app ID using "sf orchestrator app list"
-- App names should be unique, but this org may have duplicates
+- Use --app-id instead of --app-name for unique identification.
+- Get the specific app ID using "sf orchestrator app list".
+- App names should be unique, but this org may have duplicates.
 
 # error.InvalidAppId
 
@@ -116,9 +104,9 @@ App ID "%s" is not valid.
 
 # error.InvalidAppId.Actions
 
-- Verify the app ID format is correct
-- Get valid app IDs using "sf orchestrator app list"
-- App IDs should be 15 or 18 character Salesforce IDs
+- Verify the app ID format is correct.
+- Get valid app IDs using "sf orchestrator app list".
+- App IDs should be 15 or 18 character Salesforce IDs.
 
 # examples
 
@@ -140,4 +128,4 @@ App ID "%s" is not valid.
 
 - Display an app by name in your default org:
 
-  <%= config.bin %> <%= command.id %> --app-name "dashboard_app"
+  <%= config.bin %> <%= command.id %> --app-name dashboard_app

--- a/messages/appframework.display.template.md
+++ b/messages/appframework.display.template.md
@@ -1,6 +1,6 @@
 # summary
 
-Display details of a template.
+Display details about a template.
 
 # description
 
@@ -30,15 +30,15 @@ Template information helps you understand what the template provides, its intend
 
 - Display a template by name in your default org:
 
-  <%= config.bin %> <%= command.id %> --template-name "dashboard_template"
+  <%= config.bin %> <%= command.id %> --template-name dashboard_template
 
 # flags.template-id.summary
 
-The ID of the template to display.
+ID of the template to display.
 
 # flags.template-id.description
 
-Specify the unique identifier of the template you want to display. Template IDs are guaranteed to be unique within an org. Use this flag when you know the template's ID, which you can get from "sf orchestrator template list" command. Either --template-id or --template-name is required.
+Template IDs are guaranteed to be unique within an org. Use this flag when you know the template's ID, which you can get from "sf orchestrator template list" command. Either --template-id or --template-name is required.
 
 # flags.template-name.summary
 
@@ -46,23 +46,19 @@ The name of the template to display.
 
 # flags.template-name.description
 
-Specify the name of the template you want to display. Template names should be unique within an org. Use this flag when you know the template's name but not its ID. If the name contains spaces, enclose it in quotes. Either --template-id or --template-name is required.
+Template names should be unique within an org. Use this flag when you know the template's name but not its ID. If the name contains spaces, enclose it in quotes. Either --template-id or --template-name is required.
 
 # flags.target-org.summary
 
-Login username or alias for the target org.
-
-# flags.target-org.description
-
-The target org to connect to for displaying the template. This org must have Data Cloud and Tableau Next enabled and you must have the AppFrameworkViewApp user permission to view templates. The template must exist in this org.
+Login username or alias for the target org. Not required if the `target-org` configuration variable is already set.
 
 # flags.api-version.summary
 
-Override the API version used for API requests.
+Override the API version used for orchestrator API requests.
 
 # flags.api-version.description
 
-Override the API version used for orchestrator API requests. Use this flag to specify a particular API version when the default version doesn't work with your org's configuration.
+Use this flag to specify a particular API version when the default version doesn't work with your org's configuration.
 
 # fetchingTemplate
 
@@ -74,9 +70,9 @@ Either --template-id or --template-name must be provided.
 
 # error.MissingRequiredFlag.Actions
 
-- Use --template-id to specify a template by its unique ID
-- Use --template-name to specify a template by its name
-- Get template IDs and names using "sf orchestrator template list"
+- Use --template-id to specify a template by its unique ID.
+- Use --template-name to specify a template by its name.
+- Get template IDs and names using "sf orchestrator template list".
 
 # error.CertificateError
 
@@ -84,10 +80,10 @@ Error retrieving template: Certificate validation error.
 
 # error.CertificateError.Actions
 
-- This appears to be a certificate validation issue, which is common in dev environments
-- Try specifying the API version with --api-version=64.0 (or your org's version)
-- Make sure you're using the correct org with --target-org YOUR_ORG_ALIAS
-- If using a sandbox or scratch org, ensure your connection is properly authenticated
+- This appears to be a certificate validation issue, which is common in dev environments.
+- Try specifying the API version with --api-version=64.0 (or your org's version).
+- Make sure you're using the correct org with --target-org YOUR_ORG_ALIAS.
+- If using a sandbox or scratch org, ensure your connection is properly authenticated.
 
 # error.AuthenticationError
 
@@ -95,10 +91,10 @@ Error retrieving template: Authentication issue.
 
 # error.AuthenticationError.Actions
 
-- Your session may have expired or you may not have permission to access this resource
-- Try running "sf org login web" to reauthenticate
-- Ensure you have Tableau Next enabled and have permission to view templates
-- Verify the target org is correct and accessible
+- Your session may have expired or you may not have permission to access this resource.
+- Try running "sf org login web" to reauthenticate.
+- Ensure you have Tableau Next enabled and have permission to view templates.
+- Verify the target org is correct and accessible.
 
 # error.TemplateNotFound
 
@@ -106,22 +102,22 @@ Template "%s" not found.
 
 # error.TemplateNotFound.Actions
 
-- Verify that you have the correct template ID or name
-- Ensure the template exists in this org using "sf orchestrator template list"
-- Check your permissions to view templates
-- Make sure you're connected to the correct org with --target-org
+- Verify that you have the correct template ID or name.
+- Ensure the template exists in this org using "sf orchestrator template list".
+- Check your permissions to view templates.
+- Make sure you're connected to the correct org with --target-org.
 
 # error.GenericError
 
-Error retrieving template: %s
+Error retrieving template: %s.
 
 # error.GenericError.Actions
 
-- Verify that you are using an org with Data Cloud and Tableau Next enabled
-- Check that the template ID or name is correct
-- Ensure you have permission to view templates
-- Try running "sf org login web" to reauthenticate
-- Verify the target org has Data Cloud and Tableau Next properly configured
+- Verify that you are using an org with Data Cloud and Tableau Next enabled.
+- Check that the template ID or name is correct.
+- Ensure you have permission to view templates.
+- Try running "sf org login web" to reauthenticate.
+- Verify the target org has Data Cloud and Tableau Next properly configured.
 
 # error.MultipleTemplatesFound
 
@@ -129,9 +125,9 @@ Multiple templates found with name "%s".
 
 # error.MultipleTemplatesFound.Actions
 
-- Use --template-id instead of --template-name for unique identification
-- Get the specific template ID using "sf orchestrator template list"
-- Template names should be unique, but this org may have duplicates
+- Use --template-id instead of --template-name for unique identification.
+- Get the specific template ID using "sf orchestrator template list".
+- Template names should be unique, but this org may have duplicates.
 
 # error.InvalidTemplateId
 
@@ -139,6 +135,6 @@ Template ID "%s" is not valid.
 
 # error.InvalidTemplateId.Actions
 
-- Verify the template ID format is correct
-- Get valid template IDs using "sf orchestrator template list"
-- Template IDs should be 15 or 18 character Salesforce IDs
+- Verify the template ID format is correct.
+- Get valid template IDs using "sf orchestrator template list".
+- Template IDs should be 15 or 18 character Salesforce IDs.

--- a/messages/appframework.list.app.md
+++ b/messages/appframework.list.app.md
@@ -30,19 +30,15 @@ You must have Data Cloud and Tableau Next enabled in your org and the AppFramewo
 
 # flags.target-org.summary
 
-Login username or alias for the target org.
-
-# flags.target-org.description
-
-The target org to connect to for listing apps. This org must have Data Cloud and Tableau Next enabled and you must have the AppFrameworkViewApp user permission to view apps.
+Login username or alias for the target org. Not required if the `target-org` configuration variable is already set.
 
 # flags.api-version.summary
 
-Override the API version used for API requests.
+Override the API version used for orchestrator API requests.
 
 # flags.api-version.description
 
-Override the API version used for orchestrator API requests. Use this flag to specify a particular API version when the default version doesn't work with your org's configuration.
+Use this flag to specify a particular API version when the default version doesn't work with your org's configuration.
 
 # fetchingApps
 
@@ -58,13 +54,14 @@ No apps found matching the specified filters.
 
 # error.ListError
 
-Failed to list apps: %s
+Failed to list apps: %s.
 
 # error.ListError.Actions
 
-- Verify you have permissions to view apps in this org
-- Ensure your authentication to the org is valid
-- Try running with --debug for more details
+- Verify you have permissions to view apps in this org.
+- Ensure your authentication to the org is valid.
+- Try running with --debug for more details.
+  .
 
 # noResultsFound
 
@@ -76,29 +73,29 @@ Certificate error: Unable to connect to the org. This is typically caused by an 
 
 # error.CertificateError.Actions
 
-- Check your network connection and try again
-- Ensure that your network is not blocking or intercepting HTTPS requests
-- If you are behind a corporate proxy, ensure that your proxy certificates are properly configured
-- Try specifying the API version with --api-version
+- Check your network connection and try again.
+- Ensure that your network is not blocking or intercepting HTTPS requests.
+- If you are behind a corporate proxy, ensure that your proxy certificates are properly configured.
+- Try specifying the API version with --api-version.
 
 # error.AuthenticationError
 
-Authentication error: Unable to authenticate with the org. Please check your credentials and try again.
+Authentication error: Unable to authenticate with the org. Check your credentials and try again.
 
 # error.AuthenticationError.Actions
 
-- Use "sf org login web" to log in to the org again
-- Ensure that your user has the necessary permissions to access the orchestration API
-- Check if your authentication token has expired
-- Verify the target org is correct and accessible
+- Use "sf org login web" to log in to the org again.
+- Ensure that your user has the necessary permissions to access the orchestration API.
+- Check if your authentication token has expired.
+- Verify the target org is correct and accessible.
 
 # error.GenericError
 
-An error occurred while listing apps: %s
+An error occurred while listing apps: %s.
 
 # error.GenericError.Actions
 
-- Check the error message above for more details
-- Ensure that Data Cloud and Tableau Next are enabled in your org
-- Ensure that your user has the necessary permissions
-- Try running "sf org login web" to reauthenticate
+- Check the error message above for more details.
+- Ensure that Data Cloud and Tableau Next are enabled in your org.
+- Ensure that your user has the necessary permissions.
+- Try running "sf org login web" to reauthenticate.

--- a/messages/appframework.list.template.md
+++ b/messages/appframework.list.template.md
@@ -30,19 +30,15 @@ You must have Data Cloud and Tableau Next enabled in your org and the AppFramewo
 
 # flags.target-org.summary
 
-Login username or alias for the target org.
-
-# flags.target-org.description
-
-The target org to connect to for listing templates. This org must have Data Cloud and Tableau Next enabled and you must have the AppFrameworkViewApp user permission to view templates.
+Login username or alias for the target org. Not required if the `target-org` configuration variable is already set.
 
 # flags.api-version.summary
 
-Override the API version used for API requests.
+Override the API version used for orchestrator API requests.
 
 # flags.api-version.description
 
-Override the API version used for orchestrator API requests. Use this flag to specify a particular API version when the default version doesn't work with your org's configuration.
+Use this flag to specify a particular API version when the default version doesn't work with your org's configuration.
 
 # templatesFound
 
@@ -58,7 +54,7 @@ Fetching templates...
 
 # templateTypeLegend
 
-Legend: %s, %s, %s - Other template types
+Legend: %s, %s, %s - Other template types.
 
 # error.CertificateError
 
@@ -66,10 +62,10 @@ Error retrieving templates: Certificate validation error.
 
 # error.CertificateError.Actions
 
-- This appears to be a certificate validation issue, which is common in dev environments
-- Try specifying the API version with --api-version=64.0 (or your org's version)
-- Make sure you're using the correct org with --target-org YOUR_ORG_ALIAS
-- If using a sandbox or scratch org, ensure your connection is properly authenticated
+- This appears to be a certificate validation issue, which is common in dev environments.
+- Try specifying the API version with "--api-version 64.0" (or your org's version).
+- Make sure you're using the correct org with "--target-org YOUR_ORG_ALIAS".
+- If using a sandbox or scratch org, ensure your connection is properly authenticated.
 
 # error.AuthenticationError
 
@@ -77,19 +73,19 @@ Error retrieving templates: Authentication issue.
 
 # error.AuthenticationError.Actions
 
-- Your session may have expired or you may not have permission to access this resource
-- Try running "sf org login web" to reauthenticate
-- Ensure you have Data Cloud and Tableau Next enabled and have the AppFrameworkViewApp user permission to view templates
-- Verify the target org is correct and accessible
+- Your session may have expired or you may not have permission to access this resource.
+- Try running "sf org login web" to reauthenticate.
+- Ensure you have Data Cloud and Tableau Next enabled and have the AppFrameworkViewApp user permission to view templates.
+- Verify the target org is correct and accessible.
 
 # error.GenericError
 
-Error retrieving templates: %s
+Error retrieving templates: %s.
 
 # error.GenericError.Actions
 
-- Verify that you are using an org with Data Cloud and Tableau Next enabled
-- Check that your credentials and permissions are valid
-- Check your internet connection
-- Try running "sf org login web" to reauthenticate
-- Ensure the target org has Data Cloud and Tableau Next properly configured
+- Verify that you are using an org with Data Cloud and Tableau Next enabled.
+- Check that your credentials and permissions are valid.
+- Check your internet connection.
+- Try running "sf org login web" to reauthenticate.
+- Ensure the target org has Data Cloud and Tableau Next properly configured.

--- a/messages/appframework.update.app.md
+++ b/messages/appframework.update.app.md
@@ -14,35 +14,23 @@ You must have Data Cloud and Tableau Next enabled in your org and the AppFramewo
 
 # flags.target-org.summary
 
-Login username or alias for the target org.
-
-# flags.target-org.description
-
-The target org to connect to for updating the app.
+Login username or alias for the target org. Not required if the `target-org` configuration variable is already set.
 
 # flags.api-version.summary
 
-Override the API version used for API requests.
+Override the API version used for orchestrator API requests.
 
 # flags.api-version.description
 
-Override the API version used for orchestrator API requests. Use this flag to specify a particular API version when the default version doesn't work with your org's configuration.
+Use this flag to specify a particular API version when the default version doesn't work with your org's configuration.
 
 # flags.app-id.summary
 
 ID of the app to update.
 
-# flags.app-id.description
-
-The unique identifier of the app to update.
-
 # flags.app-name.summary
 
 Name of the app to update.
-
-# flags.app-name.description
-
-The name of the app to update.
 
 # flags.template-id.summary
 
@@ -50,7 +38,7 @@ ID of the template to use for the update.
 
 # flags.template-id.description
 
-The unique identifier of the template to use for updating the app. Template IDs are guaranteed to be unique within an org. Either --template-id or --template-name is required when updating the app's template. Use "sf orchestrator template list" to find available template IDs.
+Template IDs are guaranteed to be unique within an org. Either --template-id or --template-name is required when updating the app's template. Use "sf orchestrator template list" to find available template IDs.
 
 # flags.template-name.summary
 
@@ -58,15 +46,15 @@ Name of the template to use for the update.
 
 # flags.template-name.description
 
-The name of the template to use for updating the app. Template names should be unique within an org. Either --template-id or --template-name is required when updating the app's template. If the name contains spaces, enclose it in quotes.
+Template names should be unique within an org. Either --template-id or --template-name is required when updating the app's template. If the name contains spaces, enclose it in quotes.
 
 # flags.label.summary
 
-New label for the app.
+New display label for the app.
 
 # flags.label.description
 
-A new display label for the app. This is the human-readable name shown to users on the App Install History page. The label helps users identify and select the appropriate app. Use clear, descriptive labels that explain the app's purpose.
+This label is the human-readable name shown to users on the App Install History page. The label helps users identify and select the appropriate app. Use clear, descriptive labels that explain the app's purpose.
 
 # flags.description.summary
 
@@ -74,15 +62,15 @@ New description for the app.
 
 # flags.description.description
 
-A new description for the app. This provides detailed information about the app's purpose, features, and intended use cases. The description appears on the App Install History page and helps users understand when and how to use the app effectively
+This description provides detailed information about the app's purpose, features, and intended use cases. The description appears on the App Install History page and helps users understand when and how to use the app effectively
 
 # flags.runtime-method.summary
 
-Runtime method for the app.
+Runtime method for the app execution.
 
 # flags.runtime-method.description
 
-Specifies the runtime method for the app execution. This affects how the app processes data and handles user interactions. Valid values are 'sync' and 'async'. This setting overrides the app's default runtime method.
+The runtime methodaffects how the app processes data and handles user interactions. This setting overrides the app's default runtime method.
 
 # flags.log-level.summary
 
@@ -90,7 +78,7 @@ Log level for the app.
 
 # flags.log-level.description
 
-Sets the logging level for the app. This controls how much diagnostic information is captured during app execution. Valid values are 'debug', 'info', 'warn', and 'error'. This setting overrides the app's default log level.
+This level controls how much diagnostic information is captured during app execution. This setting overrides the app's default log level.
 
 # noAppSpecified
 
@@ -122,7 +110,7 @@ No template found with the specified ID or name.
 
 # updateSuccess
 
-Successfully updated app: %s
+Successfully updated app: %s.
 
 # error.MissingRequiredFlag
 
@@ -130,9 +118,9 @@ Either --app-id or --app-name must be provided.
 
 # error.MissingRequiredFlag.Actions
 
-- Use --app-id to specify an app by its unique ID
-- Use --app-name to specify an app by its name
-- Get app IDs and names using "sf orchestrator app list"
+- Use --app-id to specify an app by its unique ID.
+- Use --app-name to specify an app by its name.
+- Get app IDs and names using "sf orchestrator app list".
 
 # error.AppNotFound
 
@@ -140,10 +128,10 @@ App "%s" not found.
 
 # error.AppNotFound.Actions
 
-- Verify the app ID or name is correct
-- Use "sf orchestrator app list" to see available apps
-- Check your permissions to view apps
-- Make sure you're connected to the correct org with --target-org
+- Verify the app ID or name is correct.
+- Use "sf orchestrator app list" to see available apps.
+- Check your permissions to view apps.
+- Make sure you're connected to the correct org with --target-org.
 
 # error.TemplateNotFound
 
@@ -151,10 +139,10 @@ Template "%s" not found.
 
 # error.TemplateNotFound.Actions
 
-- Verify the template ID or name is correct
-- Use "sf orchestrator template list" to see available templates
-- Check your permissions to view templates
-- Make sure you're connected to the correct org with --target-org
+- Verify the template ID or name is correct.
+- Use "sf orchestrator template list" to see available templates.
+- Check your permissions to view templates.
+- Make sure you're connected to the correct org with --target-org.
 
 # error.NoUpdatesProvided
 
@@ -162,23 +150,23 @@ No updates provided. You must specify at least one property to update.
 
 # error.NoUpdatesProvided.Actions
 
-- Use --template-id or --template-name to change the app's template
-- Use --label to update the app's display label
-- Use --description to update the app's description
-- Use --runtime-method or --log-level to update runtime configuration
-- Specify at least one property to modify
+- Use --template-id or --template-name to change the app's template.
+- Use --label to update the app's display label.
+- Use --description to update the app's description.
+- Use --runtime-method or --log-level to update runtime configuration.
+- Specify at least one property to modify.
 
 # error.UpdateError
 
-Failed to update app: %s
+Failed to update app: %s.
 
 # error.UpdateError.Actions
 
-- Verify that you have permission to modify apps in the target org
-- Check that both the app and template exist and are accessible
-- Ensure Data Cloud and Tableau Next are enabled in your org
-- Try using a different API version with --api-version
-- Verify your authentication and org connection are valid
+- Verify that you have permission to modify apps in the target org.
+- Check that both the app and template exist and are accessible.
+- Ensure Data Cloud and Tableau Next are enabled in your org.
+- Try using a different API version with --api-version.
+- Verify your authentication and org connection are valid.
 
 # error.InsufficientPermissions
 
@@ -186,10 +174,10 @@ You don't have permission to update apps in this org.
 
 # error.InsufficientPermissions.Actions
 
-- Contact your Salesforce admin to request app modification permissions
-- Verify you're connected to the correct org with --target-org
-- Ensure Data Cloud and Tableau Next are enabled in your org
-- Check that your user profile has the AppFrameworkManageApp user permission
+- Contact your Salesforce admin to request app modification permissions.
+- Verify you're connected to the correct org with --target-org.
+- Ensure Data Cloud and Tableau Next are enabled in your org.
+- Check that your user profile has the AppFrameworkManageApp user permission.
 
 # examples
 
@@ -207,7 +195,7 @@ You don't have permission to update apps in this org.
 
 - Update an app with new template and runtime configuration:
 
-  <%= config.bin %> <%= command.id %> --target-org myOrg --app-name "analytics_app" --template-name "Analytics Template" --runtime-method async --log-level debug
+  <%= config.bin %> <%= command.id %> --target-org myOrg --app-name analytics_app --template-name "Analytics Template" --runtime-method async --log-level debug
 
 - Update an app using a specific API version:
 

--- a/messages/appframework.update.template.md
+++ b/messages/appframework.update.template.md
@@ -20,7 +20,7 @@ You must have Data Cloud and Tableau Next enabled in your org and the AppFramewo
 
 - Update a template's description by name:
 
-  <%= config.bin %> <%= command.id %> --target-org myOrg --template-name "MyTemplate" --description "Updated template description"
+  <%= config.bin %> <%= command.id %> --target-org myOrg --template-name MyTemplate --description "Updated template description"
 
 - Update both label and description:
 
@@ -36,19 +36,15 @@ You must have Data Cloud and Tableau Next enabled in your org and the AppFramewo
 
 # flags.target-org.summary
 
-Login username or alias for the target org.
-
-# flags.target-org.description
-
-The target org to connect to for updating the template. This org must have Data Cloud and Tableau Next enabled and you must have the AppFrameworkManageApp user permission to modify templates. The template must exist in this org.
+Login username or alias for the target org. Not required if the `target-org` configuration variable is already set.
 
 # flags.api-version.summary
 
-Override the API version used for API requests.
+Override the API version used for orchestrator API requests.
 
 # flags.api-version.description
 
-Override the API version used for orchestrator API requests. Use this flag to specify a particular API version when the default version doesn't work with your org's configuration.
+Use this flag to specify a particular API version when the default version doesn't work with your org's configuration.
 
 # flags.template-id.summary
 
@@ -56,7 +52,7 @@ ID of the template to update.
 
 # flags.template-id.description
 
-The unique identifier of the template to update. Template IDs are guaranteed to be unique within an org. Use this flag when you know the template's ID, which you can get from "sf orchestrator template list" command. Either --template-id or --template-name is required.
+Template IDs are guaranteed to be unique within an org. Use this flag when you know the template's ID, which you can get from "sf orchestrator template list" command. Either --template-id or --template-name is required.
 
 # flags.template-name.summary
 
@@ -64,7 +60,7 @@ Name of the template to update.
 
 # flags.template-name.description
 
-The name of the template to update. Template names should be unique within an org. Use this flag when you know the template's name but not its ID. If the name contains spaces, enclose it in quotes. Either --template-id or --template-name is required.
+Template names should be unique within an org. Use this flag when you know the template's name but not its ID. If the name contains spaces, enclose it in quotes. Either --template-id or --template-name is required.
 
 # flags.label.summary
 
@@ -72,7 +68,7 @@ New label for the template.
 
 # flags.label.description
 
-This is the human-readable name shown to users in Tableau Next. The label helps users identify and select the appropriate template when creating apps.
+This label is the human-readable name shown to users in Tableau Next. The label helps users identify and select the appropriate template when creating apps.
 
 # flags.description.summary
 
@@ -100,9 +96,9 @@ You must provide either --template-id or --template-name.
 
 # error.MissingRequiredField.Actions
 
-- Use --template-id to specify a template by its unique ID
-- Use --template-name to specify a template by its name
-- Get template IDs and names using "sf orchestrator template list"
+- Use --template-id to specify a template by its unique ID.
+- Use --template-name to specify a template by its name.
+- Get template IDs and names using "sf orchestrator template list".
 
 # error.TemplateNotFound
 
@@ -110,10 +106,10 @@ Template "%s" not found.
 
 # error.TemplateNotFound.Actions
 
-- Verify that you have the correct template ID or name
-- Ensure the template exists in this org using "sf orchestrator template list"
-- Check your permissions to view and modify templates
-- Make sure you're connected to the correct org with --target-org
+- Verify that you have the correct template ID or name.
+- Ensure the template exists in this org using "sf orchestrator template list".
+- Check your permissions to view and modify templates.
+- Make sure you're connected to the correct org with --target-org.
 
 # error.InsufficientPermissions
 
@@ -121,10 +117,10 @@ You don't have permission to update templates in this org.
 
 # error.InsufficientPermissions.Actions
 
-- Contact your Salesforce admin to request template modification permissions
-- Verify you're connected to the correct org with --target-org
-- Ensure Data Cloud and Tableau Next are enabled in your org
-- Check that your user profile has the AppFrameworkModifyApp user permission
+- Contact your Salesforce admin to request template modification permissions.
+- Verify you're connected to the correct org with --target-org.
+- Ensure Data Cloud and Tableau Next are enabled in your org.
+- Check that your user profile has the AppFrameworkModifyApp user permission.
 
 # error.NoUpdatesProvided
 
@@ -132,21 +128,21 @@ No updates provided. You must specify at least one property to update.
 
 # error.NoUpdatesProvided.Actions
 
-- Use --label to update the template's display label
-- Use --description to update the template's description
-- Specify at least one property to modify
+- Use --label to update the template's display label.
+- Use --description to update the template's description.
+- Specify at least one property to modify.
 
 # error.UpdateFailed
 
-Failed to update template: %s
+Failed to update template: %s.
 
 # error.UpdateFailed.Actions
 
-- Verify that you have permission to modify templates in the target org
-- Check that the template exists and is accessible
-- Ensure Data Cloud and Tableau Next are enabled in your org
-- Try using a different API version with --api-version
-- Verify your authentication and org connection are valid
+- Verify that you have permission to modify templates in the target org.
+- Check that the template exists and is accessible.
+- Ensure Data Cloud and Tableau Next are enabled in your org.
+- Try using a different API version with --api-version.
+- Verify your authentication and org connection are valid.
 
 # error.MultipleTemplatesFound
 
@@ -154,9 +150,9 @@ Multiple templates found with name "%s".
 
 # error.MultipleTemplatesFound.Actions
 
-- Use --template-id instead of --template-name for unique identification
-- Get the specific template ID using "sf orchestrator template list"
-- Template names should be unique, but this org may have duplicates
+- Use --template-id instead of --template-name for unique identification.
+- Get the specific template ID using "sf orchestrator template list".
+- Template names should be unique, but this org may have duplicates.
 
 # error.InvalidTemplateId
 
@@ -164,6 +160,6 @@ Template ID "%s" is not valid.
 
 # error.InvalidTemplateId.Actions
 
-- Verify the template ID format is correct
-- Get valid template IDs using "sf orchestrator template list"
-- Template IDs should be 15 or 18 character Salesforce IDs
+- Verify the template ID format is correct.
+- Get valid template IDs using "sf orchestrator template list".
+- Template IDs should be 15 or 18 character Salesforce IDs.

--- a/src/commands/orchestrator/app/create.ts
+++ b/src/commands/orchestrator/app/create.ts
@@ -33,7 +33,6 @@ export default class CreateApp extends SfCommand<string> {
   public static readonly flags = {
     'target-org': Flags.requiredOrg({
       summary: messages.getMessage('flags.target-org.summary'),
-      description: messages.getMessage('flags.target-org.description'),
       required: true,
     }),
     'api-version': Flags.orgApiVersion({
@@ -59,13 +58,11 @@ export default class CreateApp extends SfCommand<string> {
     'template-id': Flags.string({
       char: 'i',
       summary: messages.getMessage('flags.template-id.summary'),
-      description: messages.getMessage('flags.template-id.description'),
       exclusive: ['template-name'],
     }),
     'template-name': Flags.string({
       char: 't',
       summary: messages.getMessage('flags.template-name.summary'),
-      description: messages.getMessage('flags.template-name.description'),
       exclusive: ['template-id'],
     }),
     'runtime-method': Flags.string({

--- a/src/commands/orchestrator/app/delete.ts
+++ b/src/commands/orchestrator/app/delete.ts
@@ -30,7 +30,6 @@ export default class DeleteApp extends SfCommand<void> {
   public static readonly flags = {
     'target-org': Flags.requiredOrg({
       summary: messages.getMessage('flags.target-org.summary'),
-      description: messages.getMessage('flags.target-org.description'),
       required: true,
     }),
     'api-version': Flags.orgApiVersion({
@@ -40,13 +39,11 @@ export default class DeleteApp extends SfCommand<void> {
     'app-id': Flags.string({
       char: 'i',
       summary: messages.getMessage('flags.app-id.summary'),
-      description: messages.getMessage('flags.app-id.description'),
       exclusive: ['app-name'],
     }),
     'app-name': Flags.string({
       char: 'n',
       summary: messages.getMessage('flags.app-name.summary'),
-      description: messages.getMessage('flags.app-name.description'),
       exclusive: ['app-id'],
     }),
     'no-prompt': Flags.boolean({

--- a/src/commands/orchestrator/app/display.ts
+++ b/src/commands/orchestrator/app/display.ts
@@ -32,7 +32,6 @@ export default class DisplayApp extends SfCommand<AppData | undefined> {
   public static readonly flags = {
     'target-org': Flags.requiredOrg({
       summary: messages.getMessage('flags.target-org.summary'),
-      description: messages.getMessage('flags.target-org.description'),
       required: true,
     }),
     'api-version': Flags.orgApiVersion({
@@ -42,13 +41,11 @@ export default class DisplayApp extends SfCommand<AppData | undefined> {
     'app-id': Flags.string({
       char: 'i',
       summary: messages.getMessage('flags.app-id.summary'),
-      description: messages.getMessage('flags.app-id.description'),
       exclusive: ['app-name'],
     }),
     'app-name': Flags.string({
       char: 'n',
       summary: messages.getMessage('flags.app-name.summary'),
-      description: messages.getMessage('flags.app-name.description'),
       exclusive: ['app-id'],
     }),
   };

--- a/src/commands/orchestrator/app/list.ts
+++ b/src/commands/orchestrator/app/list.ts
@@ -33,7 +33,6 @@ export default class ListApp extends SfCommand<AppData[]> {
   public static readonly flags = {
     'target-org': Flags.requiredOrg({
       summary: messages.getMessage('flags.target-org.summary'),
-      description: messages.getMessage('flags.target-org.description'),
       required: true,
     }),
     'api-version': Flags.orgApiVersion({

--- a/src/commands/orchestrator/app/update.ts
+++ b/src/commands/orchestrator/app/update.ts
@@ -31,7 +31,6 @@ export default class UpdateApp extends SfCommand<string> {
   public static readonly flags = {
     'target-org': Flags.requiredOrg({
       summary: messages.getMessage('flags.target-org.summary'),
-      description: messages.getMessage('flags.target-org.description'),
       required: true,
     }),
     'api-version': Flags.orgApiVersion({
@@ -41,13 +40,11 @@ export default class UpdateApp extends SfCommand<string> {
     'app-id': Flags.string({
       char: 'i',
       summary: messages.getMessage('flags.app-id.summary'),
-      description: messages.getMessage('flags.app-id.description'),
       exclusive: ['app-name'],
     }),
     'app-name': Flags.string({
       char: 'n',
       summary: messages.getMessage('flags.app-name.summary'),
-      description: messages.getMessage('flags.app-name.description'),
       exclusive: ['app-id'],
     }),
     'template-id': Flags.string({

--- a/src/commands/orchestrator/template/create.ts
+++ b/src/commands/orchestrator/template/create.ts
@@ -33,7 +33,6 @@ export default class CreateTemplate extends SfCommand<string> {
   public static readonly flags = {
     'target-org': Flags.requiredOrg({
       summary: messages.getMessage('flags.target-org.summary'),
-      description: messages.getMessage('flags.target-org.description'),
       required: true,
     }),
     'api-version': Flags.orgApiVersion({

--- a/src/commands/orchestrator/template/delete.ts
+++ b/src/commands/orchestrator/template/delete.ts
@@ -31,7 +31,6 @@ export default class DeleteTemplate extends SfCommand<void> {
   public static readonly flags = {
     'target-org': Flags.requiredOrg({
       summary: messages.getMessage('flags.target-org.summary'),
-      description: messages.getMessage('flags.target-org.description'),
       required: true,
     }),
     'api-version': Flags.orgApiVersion({

--- a/src/commands/orchestrator/template/display.ts
+++ b/src/commands/orchestrator/template/display.ts
@@ -33,7 +33,6 @@ export default class DisplayTemplate extends SfCommand<TemplateData> {
   public static readonly flags = {
     'target-org': Flags.requiredOrg({
       summary: messages.getMessage('flags.target-org.summary'),
-      description: messages.getMessage('flags.target-org.description'),
       required: true,
     }),
     'api-version': Flags.orgApiVersion({

--- a/src/commands/orchestrator/template/list.ts
+++ b/src/commands/orchestrator/template/list.ts
@@ -34,7 +34,6 @@ export default class ListTemplate extends SfCommand<TemplateData[]> {
   public static readonly flags = {
     'target-org': Flags.requiredOrg({
       summary: messages.getMessage('flags.target-org.summary'),
-      description: messages.getMessage('flags.target-org.description'),
       required: true,
     }),
     'api-version': Flags.orgApiVersion({

--- a/src/commands/orchestrator/template/update.ts
+++ b/src/commands/orchestrator/template/update.ts
@@ -33,7 +33,6 @@ export default class UpdateTemplate extends SfCommand<TemplateData> {
   public static readonly flags = {
     'target-org': Flags.requiredOrg({
       summary: messages.getMessage('flags.target-org.summary'),
-      description: messages.getMessage('flags.target-org.description'),
       required: true,
     }),
     'api-version': Flags.orgApiVersion({


### PR DESCRIPTION
### What does this PR do?

Edits messages

### What issues does this PR fix or reference?
@W-19149055@

### Overview of suggested changes

Here's a bit of info about what I did, and why. (This section was written by a human (Juliet) and not AI. )

- Added text to  --target-org summary about it not being required if the user set the target-org config var; this makes it consistent with the same flag summary in other CLI commands.
- Removed -target-org descriptions, because they duplicated what was already in the command description (about perms, etc) (but see **note** below)
- In general, removed any flag descriptions that were duplicates of the summary  and provided no more information. (but see **note** below)
- In examples, removed unnecessary quotes, left only those where the flag value had a space.  I think this makes the examples cleaner/easier to read.
- Removed list of valid and default values from flag descriptions, because they're automatically displayed in the help, so no need to duplicate info. 
- Made a few little minor edits, mostly around using contractions and adding periods. 

**NOTE**: If only some flags have explicit descriptions, they're listed in the FLAG DESCRIPTIONS section, but this section won't also include the flags that don't have descriptions. Some people find this confusing (understandably).  This was a design decision that we made back when sf was first developed.  In hindsight, it might not have been the right decision, and maybe one day we'll change it.  But for now, the CLI team has other priorities, so that's how it will stay.  If you don't like how this works, then put the descriptions back, I totally understand :slightly_smiling_face:. 

Thanks for such awesome messages -- they're so helpful!  