### PR TITLE
@W-23253606 allow node version in npm publish

### DIFF
--- a/.github/workflows/onRelease.yml
+++ b/.github/workflows/onRelease.yml
@@ -29,4 +29,5 @@ jobs:
       sign: true
       tag: ${{ needs.getDistTag.outputs.tag || 'latest' }}
       githubTag: ${{ github.event.release.tag_name || inputs.tag }}
+      nodeVersion: ${{ vars.NODE_VERSION_OVERRIDE }}
     secrets: inherit


### PR DESCRIPTION
### What does this PR do?
Allows adding a node version override to the npm publish script
https://github.com/salesforcecli/github-workflows/blob/main/.github/workflows/npmPublish.yml#L32C7-L32C18

### What issues does this PR fix or reference?
[@W-23253606@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-23253606)